### PR TITLE
Fix butcher knife harvest

### DIFF
--- a/Config/items.xml
+++ b/Config/items.xml
@@ -2159,7 +2159,7 @@
 				<passive_effect name="BlockDamage" operation="base_set" value="7"/>
 				<passive_effect name="DamageModifier" operation="perc_add" value="0" tags="organic"/>
 				<passive_effect name="AttacksPerMinute" operation="base_set" value="70"/>
-				<passive_effect name="HarvestCount" operation="perc_add" value=".5" tags="butcherHarvest"/>
+				<passive_effect name="HarvestCount" operation="base_set" value="1" tags="butcherHarvest"/>
 				<passive_effect name="StaminaLoss" operation="base_set" value="18" tags="primary"/>
 				<passive_effect name="DegradationMax" operation="base_set" value="200,500" tier="1,6"/>
 				<passive_effect name="ModSlots" operation="base_set" value="0,5" tier="1,6"/>


### PR DESCRIPTION
Butcher knife was not giving meat, leather etc when used to harvest
animals. Changing the operation to "base_set" fixes that. Gave it a
value of 1 as compared to vanilla blades' 0.5, since your intention
seems to be a meat harvesting tool superior to the vanilla ones.